### PR TITLE
Explicitly specify basic auth header style

### DIFF
--- a/DotNetCoreSampleApplication/src/Program.cs
+++ b/DotNetCoreSampleApplication/src/Program.cs
@@ -57,7 +57,9 @@ namespace SampleApplication
             // The application now knows how to talk to the token endpoint.
 
             // Second: the application authenticates against the token endpoint
-            var tokenClient = new TokenClient(discoResult.TokenEndpoint, clientId, secret);
+            var tokenClient = new TokenClient(discoResult.TokenEndpoint, clientId, secret) {
+                BasicAuthenticationHeaderStyle = TokenClient.AuthenticationHeaderStyle.Rfc2617
+            };
 
             var tokenResponse = tokenClient.RequestClientCredentialsAsync().Result;
 

--- a/DotNetCoreSampleApplication/src/SampleApplication.csproj
+++ b/DotNetCoreSampleApplication/src/SampleApplication.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" Version="3.0.0" />
+    <PackageReference Include="IdentityModel" Version="3.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Latest IdentityModel makes it possible to configure the basic auth header style, making it possible to update to a newer version. Fixes #11 