### PR TITLE
Fixes variable interpolation in curl command

### DIFF
--- a/ShellScripts/bash_script.sh
+++ b/ShellScripts/bash_script.sh
@@ -12,4 +12,4 @@ contentTypeHeader='Content-Type: application/x-www-form-urlencoded; charset=utf-
 # request body
 requestBody='grant_type=client_credentials'
 
-curl -u $clientId:$secret -H '$acceptHeader' -H '$contentTypeHeader' -d $requestBody 'https://api.sbanken.no/identityserver/connect/token'
+curl -u "$clientId:$secret" -H "$acceptHeader" -H "$contentTypeHeader" -d "$requestBody" 'https://api.sbanken.no/identityserver/connect/token'


### PR DESCRIPTION
Single-quoted variables aren't interpolated by the shell. This caused curl to use it's default values for the Accept and Content-Type headers.