### PR TITLE
Implemented changes in authentication endpoint in java example

### DIFF
--- a/JavaSampleApplication/pom.xml
+++ b/JavaSampleApplication/pom.xml
@@ -24,11 +24,6 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>com.google.http-client</groupId>
-            <artifactId>google-http-client</artifactId>
-            <version>1.23.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.1</version>
@@ -36,7 +31,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 </project>

--- a/JavaSampleApplication/src/main/java/no/ohuen/sbanken/SbankenClient.java
+++ b/JavaSampleApplication/src/main/java/no/ohuen/sbanken/SbankenClient.java
@@ -11,6 +11,9 @@ import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.util.Base64;
 
 /**
@@ -19,7 +22,7 @@ import java.util.Base64;
  */
 public class SbankenClient {
 
-    private static final String IDENTITY_SERVER_URL = "https://api.sbanken.no/identityserver/connect/token";
+    private static final String IDENTITY_SERVER_URL = "https://auth.sbanken.no/identityserver/connect/token";
     private static final String ACCOUNT_SERVICE_URL = "https://api.sbanken.no/bank/api/v1/accounts/";
     private final static Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
@@ -57,10 +60,9 @@ public class SbankenClient {
         return respStr;
     }
 
-    private static String getBase64AuthString(String clientId, String secret) {
-        String basicAuth = new String(Base64.getEncoder().encode(
-                new StringBuilder(256).append(clientId).append(':').append(secret).toString().getBytes()));
-        return basicAuth;
+    private static String getBase64AuthString(String clientId, String secret) throws UnsupportedEncodingException {
+        Charset charSet = Charset.forName("UTF-8");
+        return new String(Base64.getEncoder().encode(String.format("%s:%s", URLEncoder.encode(clientId, charSet.name()), URLEncoder.encode(secret, charSet.name())).getBytes(charSet)), charSet);
     }
 
     private static String getAccessToken(HttpRequestFactory requestFactory, String basicAuth) throws IOException {

--- a/JavaSampleApplication/src/main/java/no/ohuen/sbanken/SbankenClient.java
+++ b/JavaSampleApplication/src/main/java/no/ohuen/sbanken/SbankenClient.java
@@ -1,20 +1,20 @@
 package no.ohuen.sbanken;
 
-import com.google.api.client.http.ByteArrayContent;
-import com.google.api.client.http.GenericUrl;
-import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.http.HttpRequest;
-import com.google.api.client.http.HttpRequestFactory;
-import com.google.api.client.http.HttpResponse;
-import com.google.api.client.http.HttpTransport;
-import com.google.api.client.http.apache.ApacheHttpTransport;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  *
@@ -32,7 +32,7 @@ public class SbankenClient {
      * @param args
      * @throws IOException
      */
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws IOException, URISyntaxException, InterruptedException {
         if (args.length != 3) {
             throw new RuntimeException("Usage: SbankenClient <clientId> <secret> <userId>");
         }
@@ -40,48 +40,38 @@ public class SbankenClient {
         String secret = args[1];
         String userId = args[2];
         String basicAuth = getBase64AuthString(clientId, secret);
-        HttpTransport transport = new ApacheHttpTransport();
-        HttpRequestFactory requestFactory = transport.createRequestFactory();
-        String token = getAccessToken(requestFactory, basicAuth);
-        String respStr = getAccountInfo(requestFactory, userId, token);
+        var httpClient = HttpClient.newHttpClient();
+        String token = getAccessToken(httpClient, basicAuth);
+        String respStr = getAccountInfo(httpClient, userId, token);
         System.out.println(respStr);
     }
 
-    private static String getAccountInfo(HttpRequestFactory requestFactory, String userId, String token) throws IOException {
+    private static String getAccountInfo(HttpClient httpClient, String userId, String token) throws IOException, URISyntaxException, InterruptedException {
         //now we have token and can qury sbanken api
-        HttpRequest serviceRequest = requestFactory.buildGetRequest(new GenericUrl(ACCOUNT_SERVICE_URL));
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("customerId", userId);
-        headers.setAccept("application/json");
-        headers.setAuthorization("Bearer " + token);
-        serviceRequest.setHeaders(headers);
-        HttpResponse response = serviceRequest.execute();
-        String respStr = response.parseAsString();
-        return respStr;
+        var serviceRequest = HttpRequest.newBuilder(new URI(ACCOUNT_SERVICE_URL))
+                .header("Accept", "application/json")
+                .header("Authorization", "Bearer " + token)
+                .header("customerId", userId)
+                .build();
+        return  httpClient.send(serviceRequest, HttpResponse.BodyHandlers.ofString()).body();
     }
 
     private static String getBase64AuthString(String clientId, String secret) throws UnsupportedEncodingException {
-        Charset charSet = Charset.forName("UTF-8");
-        return new String(Base64.getEncoder().encode(String.format("%s:%s", URLEncoder.encode(clientId, charSet.name()), URLEncoder.encode(secret, charSet.name())).getBytes(charSet)), charSet);
+        return new String(Base64.getEncoder().encode(String.format("%s:%s", URLEncoder.encode(clientId, UTF_8), URLEncoder.encode(secret, UTF_8)).getBytes(UTF_8)), UTF_8);
     }
 
-    private static String getAccessToken(HttpRequestFactory requestFactory, String basicAuth) throws IOException {
-
-        HttpRequest tokenRequest = requestFactory.buildPostRequest(new GenericUrl(IDENTITY_SERVER_URL), null);
-        HttpHeaders headers = new HttpHeaders();
-        headers.setAccept("application/json");
-        headers.setAuthorization("Basic " + basicAuth);
-        tokenRequest.setHeaders(headers);
-        tokenRequest.setContent(new ByteArrayContent("application/x-www-form-urlencoded; charset=utf-8",
-                "grant_type=client_credentials".getBytes()));
-        HttpResponse response = tokenRequest.execute();
-        String respStr = response.parseAsString();
-        Token tokenObj = GSON.fromJson(respStr, Token.class);
-        return tokenObj.access_token;
+    static String getAccessToken(HttpClient httpClient, String basicAuth) throws IOException, URISyntaxException, InterruptedException {
+        var serviceRequest = HttpRequest.newBuilder(new URI(IDENTITY_SERVER_URL))
+                .header("Accept", "application/json")
+                .header("Authorization", "Basic " + basicAuth)
+                .header("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+                .POST(HttpRequest.BodyPublishers.ofByteArray("grant_type=client_credentials".getBytes()))
+                .build();
+        var response = httpClient.send(serviceRequest, HttpResponse.BodyHandlers.ofString());
+        return GSON.fromJson(response.body(), Token.class).access_token;
     }
 
     private static class Token {
-
-        public String access_token;
+        String access_token;
     }
 }


### PR DESCRIPTION
The Java example has stopped working because of the changes made to authentication.
This pull request contains two commits, one that makes the example work in Java 8, and one that upgrades to Java 11 and makes use of the nye built-in HTTP client.