### PR TITLE
doc: url encode client id and secret in bash script

### DIFF
--- a/ShellScripts/bash_script.sh
+++ b/ShellScripts/bash_script.sh
@@ -6,6 +6,8 @@
 # dnf install jq
 
 # setup
+#
+# remember to urlencode clientId and secret
 clientId='*******************'
 secret='******************************'
 userId='***********'


### PR DESCRIPTION
Without it you may get a `"{"error":"invalid_client"}"`.