### PR TITLE
PythonSampleApplication - Added requirements.txt

### DIFF
--- a/PythonSampleApplication/requirements.txt
+++ b/PythonSampleApplication/requirements.txt
@@ -1,0 +1,8 @@
+certifi==2019.9.11
+chardet==3.0.4
+idna==2.8
+oauthlib==3.1.0
+python-dotenv==0.10.3
+requests==2.22.0
+requests-oauthlib==1.2.0
+urllib3==1.25.6


### PR DESCRIPTION
Having this file prevents the guessing game about which packages are needed to run this application. Now people can simply run `pip install -r requirements.txt`